### PR TITLE
Filter by threshold

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,14 @@
 
 `mem-info` uses [PVP Versioning][1].
 
+## 0.3.1.0 -- 2025-02-18
+
+- Add option -m (--min-reported)
+
+  This filters out processes with low memory by specifying a lower bound for
+  output. Correct filter amounts are specified as quantities along with a unit;
+  one of KiB, MiB, GiB or TiB
+
 ## 0.3.0.1 -- 2025-01-17
 
 - Fix test data generation in QuickCheck test

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ $ chmod u+x $my_local_bin
 Usage: printmem [-s|--split-args] [-t|--total] [-d|--discriminate-by-pid]
                 [-S|--show_swap] [-r|--reverse] [-w|--watch N]
                 [(-p|--pids <pid1> [ -p pid2 ... -p pidN ])]
-                [-b|--order-by <Private | Swap | Shared | Count>]
+                [-b|--order-by < private | swap | shared | count >]
+                [-y|--output-style < [normal] | csv >]
+                [-m|--min-reported <threshold>[K|M|G|T]iB, e.g 1.1KiB | 2MiB | 4.0GiB]
 
 Available options:
   -h,--help                Show this help text
@@ -72,13 +74,24 @@ Available options:
   -t,--total               Only show the total value
   -d,--discriminate-by-pid Show by process rather than by program
   -S,--show_swap           Show swap information
-  -r,--reverse             Reverses the order of output, making it descending
+  -r,--reverse             Reverses the output order so that output descends on
+                           the sorting field
   -w,--watch N             Measure and show memory every N seconds (N > 0)
   -p,--pids <pid1> [ -p pid2 ... -p pidN ]
                            Only show memory usage of the specified PIDs
-  -b,--order-by <Private | Swap | Shared | Count>
+  -b,--order-by < private | swap | shared | count >
                            Orders the output by ascending values of the given
                            field
+  -y,--output-style < [normal] | csv >
+                           Determines how the output report is presented;
+                           'normal' is the default and is the same as if this
+                           option was omitted; 'csv' outputs the usage and
+                           header rows in csv format, with all values in KiB and
+                           no 'total' row. With 'csv', the --total (-t) flag is
+                           ignored
+  -m,--min-reported <threshold>[K|M|G|T]iB, e.g 1.1KiB | 2MiB | 4.0GiB
+                           Specifies a minimum below which memory values are
+                           omitted
 ```
 
 ### Example output

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               mem-info
-version:            0.3.0.1
+version:            0.3.1.0
 synopsis:           Print the core memory usage of programs
 description:
   A utility to accurately report the core memory usage of programs.

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -498,13 +498,10 @@ checkAllExist pids =
 
 allKnownProcs :: IO (Either NotRun (NonEmpty ProcessID))
 allKnownProcs =
-  let readNaturals = fmap (mapMaybe readMaybe)
-      orNoPids = maybe (Left NoRecords) Right
-   in readNaturals (listDirectory procRoot)
-        >>= filterM pidExeExists
-        >>= pure
-        . orNoPids
-        . nonEmpty
+  let readIdsMaybe = fmap (mapMaybe readMaybe)
+      readProcessIDs = readIdsMaybe (listDirectory procRoot)
+      orNoPids = maybe (Left NoRecords) Right . nonEmpty
+   in readProcessIDs >>= filterM pidExeExists >>= pure . orNoPids
 
 
 baseName :: Text -> Text

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -409,8 +409,8 @@ parentNameIfMatched pid candidate = do
 
 -- | Represents errors that prevent a report from being generated
 data NotRun
-  = PidLost LostPid
-  | MissingPids (NonEmpty ProcessID)
+  = PidLost !LostPid
+  | MissingPids !(NonEmpty ProcessID)
   | NeedsRoot
   | OddKernel
   | NoRecords
@@ -429,12 +429,12 @@ fmtNotRun NoRecords = "could not find any process records"
 records.
 -}
 data LostPid
-  = NoExeFile ProcessID
-  | NoStatusCmd ProcessID
-  | NoStatusParent ProcessID
-  | NoCmdLine ProcessID
-  | BadStatm ProcessID
-  | NoProc ProcessID
+  = NoExeFile !ProcessID
+  | NoStatusCmd !ProcessID
+  | NoStatusParent !ProcessID
+  | NoCmdLine !ProcessID
+  | BadStatm !ProcessID
+  | NoProc !ProcessID
   deriving (Eq, Show)
 
 

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -404,7 +404,7 @@ parentNameIfMatched pid candidate = do
     Right si ->
       nameFromExeOnly (siParent si) >>= \case
         Right n | n == candidate -> pure $ Right n
-        _ -> pure $ Right $ siName si
+        _anyLostPid -> pure $ Right $ siName si
 
 
 -- | Represents errors that prevent a report from being generated

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -18,6 +18,7 @@ module System.MemInfo.Choices (
   PrintOrder (..),
   Power (..),
   Mem (..),
+  asFloat,
   memReader,
   cmdInfo,
   getChoices,
@@ -237,6 +238,13 @@ data Power = Ki | Mi | Gi | Ti
     (Eq, Read, Show, Ord, Enum, Bounded, Generic)
 
 
+floatingFactor :: Power -> Double
+floatingFactor Ki = 1.0
+floatingFactor Mi = 1024.0
+floatingFactor Gi = 1024.0 ** 2
+floatingFactor Ti = 1024.0 ** 3
+
+
 powerReader :: Text -> Either String (Power, Text)
 powerReader x =
   let (want, extra) = Text.splitAt 3 $ Text.stripStart x
@@ -251,6 +259,10 @@ powerReader x =
 -- | Represents an amount of memory
 data Mem = Mem !Power !Deci
   deriving (Eq, Show, Ord, Generic)
+
+
+asFloat :: Mem -> Double
+asFloat (Mem pow x) = realToFrac x * floatingFactor pow
 
 
 memReader :: Text -> Either String (Mem, Text)

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -16,11 +16,14 @@ module System.MemInfo.Choices (
   Choices (..),
   Style (..),
   PrintOrder (..),
+  Power (..),
+  Mem (..),
   cmdInfo,
   getChoices,
 ) where
 
 import qualified Data.Text as Text
+import Data.Text.Read (Reader, rational)
 import GHC.Generics (Generic)
 import Options.Applicative (
   Parser,
@@ -209,3 +212,12 @@ readOrNotAllowed :: (Read a) => (String -> String) -> String -> Either String a
 readOrNotAllowed f x = case readEither $ f x of
   Left _ -> Left $ "value '" ++ x ++ "' is not permitted"
   right -> right
+-- | Represents the power in memory quanity unit
+data Power = Ki | Mi | Gi | Ti deriving (Eq, Read, Show, Ord, Enum, Bounded)
+
+
+-- | Represents an amount of memory
+data Mem = Mem !Power !Float
+  deriving (Eq, Show, Ord)
+
+

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -210,7 +210,7 @@ autoOrNotAllowed = eitherReader $ readOrNotAllowed id
 
 readOrNotAllowed :: (Read a) => (String -> String) -> String -> Either String a
 readOrNotAllowed f x = case readEither $ f x of
-  Left _ -> Left $ "value '" ++ x ++ "' is not permitted"
+  Left _ignored -> Left $ "value '" ++ x ++ "' is not permitted"
   right -> right
 -- | Represents the power in memory quanity unit
 data Power = Ki | Mi | Gi | Ti deriving (Eq, Read, Show, Ord, Enum, Bounded)

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -87,61 +87,61 @@ parseChoices =
 
 parseChoicesPidsToShow :: Parser (NonEmpty ProcessID)
 parseChoicesPidsToShow =
-  some1
-    $ option positiveNum
-    $ short 'p'
-    <> long "pids"
-    <> metavar "<pid1> [ -p pid2 ... -p pidN ]"
-    <> help "Only show memory usage of the specified PIDs"
+  some1 $
+    option positiveNum $
+      short 'p'
+        <> long "pids"
+        <> metavar "<pid1> [ -p pid2 ... -p pidN ]"
+        <> help "Only show memory usage of the specified PIDs"
 
 
 parseSplitArgs :: Parser Bool
 parseSplitArgs =
-  switch
-    $ short 's'
-    <> long "split-args"
-    <> help "Show and separate by all command line arguments"
+  switch $
+    short 's'
+      <> long "split-args"
+      <> help "Show and separate by all command line arguments"
 
 
 parseOnlyTotal :: Parser Bool
 parseOnlyTotal =
-  switch
-    $ short 't'
-    <> long "total"
-    <> help "Only show the total value"
+  switch $
+    short 't'
+      <> long "total"
+      <> help "Only show the total value"
 
 
 parseReversed :: Parser Bool
 parseReversed =
-  switch
-    $ short 'r'
-    <> long "reverse"
-    <> help "Reverses the output order so that output descends on the sorting field"
+  switch $
+    short 'r'
+      <> long "reverse"
+      <> help "Reverses the output order so that output descends on the sorting field"
 
 
 parseDiscriminateByPid :: Parser Bool
 parseDiscriminateByPid =
-  switch
-    $ short 'd'
-    <> long "discriminate-by-pid"
-    <> help "Show by process rather than by program"
+  switch $
+    short 'd'
+      <> long "discriminate-by-pid"
+      <> help "Show by process rather than by program"
 
 
 parseShowSwap :: Parser Bool
 parseShowSwap =
-  switch
-    $ short 'S'
-    <> long "show_swap"
-    <> help "Show swap information"
+  switch $
+    short 'S'
+      <> long "show_swap"
+      <> help "Show swap information"
 
 
 parseWatchPeriodSecs :: Parser Natural
 parseWatchPeriodSecs =
-  option positiveNum
-    $ short 'w'
-    <> long "watch"
-    <> metavar "N"
-    <> help "Measure and show memory every N seconds (N > 0)"
+  option positiveNum $
+    short 'w'
+      <> long "watch"
+      <> metavar "N"
+      <> help "Measure and show memory every N seconds (N > 0)"
 
 
 positiveNum :: (Read a, Ord a, Num a) => ReadM a
@@ -156,11 +156,11 @@ positiveNum =
 
 parsePrintOrder :: Parser PrintOrder
 parsePrintOrder =
-  option autoIgnoreCase
-    $ short 'b'
-    <> long "order-by"
-    <> metavar "< private | swap | shared | count >"
-    <> help "Orders the output by ascending values of the given field"
+  option autoIgnoreCase $
+    short 'b'
+      <> long "order-by"
+      <> metavar "< private | swap | shared | count >"
+      <> help "Orders the output by ascending values of the given field"
 
 
 -- | Determines the order in which @MemUsages@ in a report are printed out
@@ -174,11 +174,11 @@ data PrintOrder
 
 parseStyle :: Parser Style
 parseStyle =
-  option autoIgnoreCase
-    $ short 'y'
-    <> long "output-style"
-    <> metavar "< [normal] | csv >"
-    <> help (Text.unpack styleHelp)
+  option autoIgnoreCase $
+    short 'y'
+      <> long "output-style"
+      <> metavar "< [normal] | csv >"
+      <> help (Text.unpack styleHelp)
 
 
 styleHelp :: Text

--- a/src/System/MemInfo/Print.hs
+++ b/src/System/MemInfo/Print.hs
@@ -15,6 +15,7 @@ This module provides functions that format the output of the __printmem__ comman
 -}
 module System.MemInfo.Print (
   AsCmdName (asCmdName),
+  fmtMem,
   fmtAsHeader,
   fmtOverall,
   fmtMemUsage,
@@ -106,7 +107,7 @@ columnWidth :: Int
 columnWidth = 10
 
 
-doFmt :: Power -> Float -> Text
+doFmt :: (Fractional a, Real a) => Power -> a -> Text
 doFmt =
   let doFmt' p x = "" +| fixedF 1 x |+ " " +|| p ||+ "B"
       go p x | p == maxBound = doFmt' p x

--- a/src/System/MemInfo/Print.hs
+++ b/src/System/MemInfo/Print.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData #-}
 {-# LANGUAGE TypeApplications #-}
 
 {- |

--- a/src/System/MemInfo/Print.hs
+++ b/src/System/MemInfo/Print.hs
@@ -107,17 +107,17 @@ columnWidth :: Int
 columnWidth = 10
 
 
-doFmt :: (Fractional a, Real a) => Power -> a -> Text
+doFmt :: Power -> Double -> Text
 doFmt =
   let doFmt' p x = "" +| fixedF 1 x |+ " " +|| p ||+ "B"
       go p x | p == maxBound = doFmt' p x
-      go p x | x > 1000 = doFmt (succ p) (x / 1024)
+      go p x | x >= 1024 = doFmt (succ p) (x / 1024.0)
       go p x = doFmt' p x
    in go
 
 
 fmtMem :: Mem -> Text
-fmtMem (Mem p x) = doFmt p x
+fmtMem (Mem p x) = doFmt p $ realToFrac x
 
 
 hdrPrivate, hdrShared, hdrRamUsed, hdrSwapUsed, hdrProgram, hdrCount, hdrPid :: Text

--- a/src/System/MemInfo/SysInfo.hs
+++ b/src/System/MemInfo/SysInfo.hs
@@ -91,8 +91,8 @@ data ReportBud = ReportBud
   , rbHasPss :: !Bool
   , rbHasSwapPss :: !Bool
   , rbHasSmaps :: !Bool
-  , rbRamFlaws :: Maybe RamFlaw
-  , rbSwapFlaws :: Maybe SwapFlaw
+  , rbRamFlaws :: !(Maybe RamFlaw)
+  , rbSwapFlaws :: !(Maybe SwapFlaw)
   }
   deriving (Eq, Show)
 

--- a/test/MemInfo/OrphanInstances.hs
+++ b/test/MemInfo/OrphanInstances.hs
@@ -17,13 +17,20 @@ SPDX-License-Identifier: BSD3
 -}
 module MemInfo.OrphanInstances where
 
+import Data.Fixed (Deci)
 import Data.GenValidity (GenValid (..))
 import Data.GenValidity.Text ()
 import Data.List.NonEmpty (nonEmpty)
-import System.MemInfo.Choices (Choices (..), PrintOrder, Style)
+import System.MemInfo.Choices (
+  Choices (..),
+  Mem (..),
+  Power,
+  PrintOrder,
+  Style,
+ )
 import System.MemInfo.Proc (ExeInfo (..), StatusInfo)
 import System.Posix.Types (CPid (..), ProcessID)
-import Test.QuickCheck (Gen, frequency, suchThat)
+import Test.QuickCheck (Gen, chooseInt, elements, frequency, suchThat)
 import Test.QuickCheck.Gen (listOf)
 import Test.Validity (Validity)
 
@@ -38,6 +45,13 @@ instance GenValid ExeInfo where
 
 genPositive :: (GenValid a, Num a, Ord a) => Gen a
 genPositive = genValid `suchThat` (> 0)
+
+
+gen2Dp :: Gen Deci
+gen2Dp = do
+  dps <- fromIntegral <$> chooseInt (10, 99)
+  strength <- elements [1.0, 10.0, 100.0]
+  pure $ (dps / 10.0) * strength
 
 
 deriving anyclass instance GenValid StatusInfo
@@ -64,10 +78,28 @@ deriving instance Validity Style
 deriving instance GenValid Style
 
 
+deriving instance Validity Power
+
+
+deriving instance GenValid Power
+
+
+deriving instance Validity Mem
+
+
+deriving instance GenValid Mem
+
+
 instance GenValid Choices where
   genValid =
     let genPositiveMb = frequency [(1, pure Nothing), (5, Just <$> genPositive)]
         genPids = nonEmpty <$> listOf genPositive
+        genValidMem = Mem <$> genValid <*> gen2Dp
+        genOptionalMem =
+          frequency
+            [ (1, pure Nothing)
+            , (5, Just <$> genValidMem)
+            ]
      in Choices
           <$> genValid
           <*> genValid
@@ -78,3 +110,4 @@ instance GenValid Choices where
           <*> genPids
           <*> genValid
           <*> genValid
+          <*> genOptionalMem


### PR DESCRIPTION
Adds the flag -m|--min-reported

to implement a [ps_mem feature request](https://github.com/pixelb/ps_mem/issues/78)

This filters out processes with low memory by specifying a lower bound for output. 
Correct filter amounts are specified as quantities along with a unit; one of KiB, MiB, GiB or TiB

E.g,

`printmem --b private -m 1Gi`