### PR TITLE
Make the procRoot an explicit argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,19 @@
 
 `mem-info` uses [PVP Versioning][1].
 
+## 0.4.0.0 -- 2025-03-02
+
+- Add option --proc-root
+
+  Used to specify an alternate process root than the default, _/proc_. This
+  allows reporting of process status for other machines whose proc information
+  has been mounted or synced to a local filesystem
+  
+- Breaking changes:
+
+* [ProcNamer][2] takes an additional argument that specifies the proc filesystem root
+
+
 ## 0.3.1.0 -- 2025-02-18
 
 - Add option -m (--min-reported)
@@ -42,3 +55,4 @@
 * Initial version.
 
 [1]: https://pvp.haskell.org
+[2]: https://hackage.haskell.org/package/mem-info-0.3.1.0/docs/System-MemInfo.html#t:ProcNamer

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -51,6 +51,7 @@ library
     , filepath              >=1.4.2  && <1.6
     , fmt                   >=0.6.3  && <0.8
     , hashable              >=1.4.2  && <1.6
+    , mtl                   >=2.0 && <2.3 || > 2.3 && <2.5
     , optparse-applicative  >=0.18.1 && <0.19
     , text                  >=1.2.3  && <2.2
     , unix                  >=2.7.2  && <2.9

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -71,6 +71,7 @@ test-suite test
     MemInfo.Files.Root
     MemInfo.Files.Smap
     MemInfo.OrphanInstances
+    MemInfo.MemInfoSpec
     MemInfo.PrintSpec
     MemInfo.ProcSpec
     MemInfo.SysInfoSpec

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -77,6 +77,8 @@ test-suite test
   ghc-options:      -threaded -rtsopts -with-rtsopts=-N -Wall -fwarn-tabs
   build-depends:
     , base
+    , filepath
+    , directory
     , fmt
     , genvalidity
     , genvalidity-hspec
@@ -87,6 +89,7 @@ test-suite test
     , optparse-applicative  >=0.18.1 && <0.19
     , QuickCheck
     , text
+    , temporary             >= 1.2 && < 1.4
     , unix
 
 -- printmem is the printmem command

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -68,6 +68,7 @@ test-suite test
   hs-source-dirs:   test
   other-modules:
     MemInfo.ChoicesSpec
+    MemInfo.Files.Root
     MemInfo.Files.Smap
     MemInfo.OrphanInstances
     MemInfo.PrintSpec

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -68,6 +68,7 @@ test-suite test
   hs-source-dirs:   test
   other-modules:
     MemInfo.ChoicesSpec
+    MemInfo.Files.Smap
     MemInfo.OrphanInstances
     MemInfo.PrintSpec
     MemInfo.ProcSpec

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -78,6 +78,7 @@ test-suite test
   build-depends:
     , base
     , filepath
+    , containers
     , directory
     , fmt
     , genvalidity

--- a/mem-info.cabal
+++ b/mem-info.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               mem-info
-version:            0.3.1.0
+version:            0.4.0.0
 synopsis:           Print the core memory usage of programs
 description:
   A utility to accurately report the core memory usage of programs.

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -79,6 +79,7 @@ import System.MemInfo.Choices (
   PrintOrder (..),
   Style (..),
   asFloat,
+  defaultRoot,
   getChoices,
  )
 import System.MemInfo.Prelude
@@ -265,7 +266,7 @@ unfoldMemUsage namer mkCmd bud = do
 root is the linux default
 -}
 readForOnePid :: ProcessID -> IO (Either NotRun (ProcName, MemUsage))
-readForOnePid = readForOnePid' procRoot
+readForOnePid = readForOnePid' defaultRoot
 
 
 -- | Load the @'MemUsage'@ of a program specified by its @ProcessID@
@@ -348,7 +349,7 @@ reportFlaws bud showSwap onlyTotal = do
 
 
 verify :: Choices -> IO ReportBud
-verify cs = verify' procRoot (choicePidsToShow cs) >>= either (haltErr . fmtNotRun) pure
+verify cs = verify' defaultRoot (choicePidsToShow cs) >>= either (haltErr . fmtNotRun) pure
 
 
 verify' :: FilePath -> Maybe (NonEmpty ProcessID) -> IO (Either NotRun ReportBud)
@@ -358,10 +359,6 @@ verify' root pidsMb = do
   case pidsMb of
     Just pids -> checkAllExist root pids >>= thenMkBud
     Nothing -> allKnownProcs root >>= thenMkBud
-
-
-procRoot :: FilePath
-procRoot = "/proc"
 
 
 -- | The root of the process file hierarchy

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -71,7 +71,6 @@ import Fmt (
   listF,
   (+|),
   (|+),
-  (|++|),
  )
 import System.Exit (exitFailure)
 import System.MemInfo.Choices (
@@ -362,15 +361,15 @@ verify' root pidsMb = do
 
 
 procRoot :: FilePath
-procRoot = "/proc/"
+procRoot = "/proc"
 
 
 -- | The root of the process file hierarchy
 type ProcRoot = FilePath
 
 
-pidPath :: (MonadReader ProcRoot m) => String -> ProcessID -> m FilePath
-pidPath base pid = ask >>= \root -> pure $ "" +| root |++| toInteger pid |+ "/" +| base |+ ""
+pidPath :: (MonadReader ProcRoot m) => FilePath -> ProcessID -> m FilePath
+pidPath base pid = ask >>= \root -> pure $ "" +| root |+ "/" +| toInteger pid |+ "/" +| base |+ ""
 
 
 {- | pidExists returns false for any ProcessID that does not exist or cannot

--- a/src/System/MemInfo.hs
+++ b/src/System/MemInfo.hs
@@ -349,7 +349,7 @@ reportFlaws bud showSwap onlyTotal = do
 
 
 verify :: Choices -> IO ReportBud
-verify cs = verify' defaultRoot (choicePidsToShow cs) >>= either (haltErr . fmtNotRun) pure
+verify cs = verify' (choiceProcRoot cs) (choicePidsToShow cs) >>= either (haltErr . fmtNotRun) pure
 
 
 verify' :: FilePath -> Maybe (NonEmpty ProcessID) -> IO (Either NotRun ReportBud)

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -141,7 +141,7 @@ parseDiscriminateByPid =
 parseRoot :: Parser FilePath
 parseRoot =
   option str $
-    long "proc_root"
+    long "proc-root"
       <> help "the root directory of the process file hierachy"
       <> value defaultRoot
       <> showDefault

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -22,6 +22,7 @@ module System.MemInfo.Choices (
   memReader,
   cmdInfo,
   getChoices,
+  defaultRoot,
 ) where
 
 import Data.Fixed (Deci)
@@ -270,3 +271,7 @@ memReader x = do
   (num, rest) <- rational (Text.stripStart x)
   (power, extra) <- powerReader rest
   pure (Mem power num, extra)
+
+
+defaultRoot :: FilePath
+defaultRoot = "/proc"

--- a/src/System/MemInfo/Choices.hs
+++ b/src/System/MemInfo/Choices.hs
@@ -44,7 +44,10 @@ import Options.Applicative (
   optional,
   readerError,
   short,
+  showDefault,
+  str,
   switch,
+  value,
  )
 import Options.Applicative.NonEmpty (some1)
 import System.MemInfo.Prelude
@@ -62,6 +65,7 @@ data Choices = Choices
   , choiceByPid :: !Bool
   , choiceShowSwap :: !Bool
   , choiceReversed :: !Bool
+  , choiceProcRoot :: !FilePath
   , choiceWatchSecs :: !(Maybe Natural)
   , choicePidsToShow :: !(Maybe (NonEmpty ProcessID))
   , choicePrintOrder :: !(Maybe PrintOrder)
@@ -84,6 +88,7 @@ parseChoices =
     <*> parseDiscriminateByPid
     <*> parseShowSwap
     <*> parseReversed
+    <*> parseRoot
     <*> optional parseWatchPeriodSecs
     <*> optional parseChoicesPidsToShow
     <*> optional parsePrintOrder
@@ -131,6 +136,15 @@ parseDiscriminateByPid =
     short 'd'
       <> long "discriminate-by-pid"
       <> help "Show by process rather than by program"
+
+
+parseRoot :: Parser FilePath
+parseRoot =
+  option str $
+    long "proc_root"
+      <> help "the root directory of the process file hierachy"
+      <> value defaultRoot
+      <> showDefault
 
 
 parseShowSwap :: Parser Bool

--- a/src/System/MemInfo/Prelude.hs
+++ b/src/System/MemInfo/Prelude.hs
@@ -51,9 +51,13 @@ import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Numeric.Natural (Natural)
 import System.Directory (
+  doesDirectoryExist,
   doesFileExist,
+  getPermissions,
   getSymbolicLinkTarget,
   listDirectory,
+  readable,
+  searchable,
  )
 import System.FilePath (takeBaseName)
 import System.IO (stderr)

--- a/src/System/MemInfo/SysInfo.hs
+++ b/src/System/MemInfo/SysInfo.hs
@@ -58,12 +58,12 @@ fickleSharing k = k >= (2, 6, 1) && k <= (2, 6, 9)
 
 
 -- | Determines the version of the Linux kernel on the current system.
-readKernelVersion :: IO (Maybe KernelVersion)
-readKernelVersion = parseKernelVersion <$> Text.readFile kernelVersionPath
+readKernelVersion :: FilePath -> IO (Maybe KernelVersion)
+readKernelVersion = fmap parseKernelVersion . Text.readFile . kernelVersionPath
 
 
-kernelVersionPath :: String
-kernelVersionPath = "/proc/sys/kernel/osrelease"
+kernelVersionPath :: FilePath -> FilePath
+kernelVersionPath root = "" +| root |+ "/sys/kernel/osrelease"
 
 
 -- | Parses @Text@ into a @'KernelVersion'@
@@ -201,7 +201,7 @@ mkReportBud rbProcRoot rbPids = do
   _doesRootExist <- doesFileExist rbProcRoot
   rbHasSmaps <- doesFileExist smapsPath
   (rbHasPss, rbHasSwapPss) <- memtypes <$> readUtf8Text smapsPath
-  readKernelVersion >>= \case
+  readKernelVersion rbProcRoot >>= \case
     Nothing -> pure Nothing
     Just rbKernel ->
       fmap Just $

--- a/src/System/MemInfo/SysInfo.hs
+++ b/src/System/MemInfo/SysInfo.hs
@@ -152,8 +152,7 @@ fmtSwapFlaws ExactForIsolatedSwap =
 -}
 checkForFlaws :: ReportBud -> IO ReportBud
 checkForFlaws bud = do
-  let pid = NE.head $ rbPids bud
-      version = rbKernel bud
+  let version = rbKernel bud
       fickleShared = fickleSharing version
       ReportBud
         { rbHasPss = hasPss
@@ -162,7 +161,7 @@ checkForFlaws bud = do
         } = bud
   (rbRamFlaws, rbSwapFlaws) <- case version of
     (2, 4, _patch) -> do
-      let memInfoPath = pidPath (rbProcRoot bud) "meminfo" pid
+      let memInfoPath = meminfoPathOf (rbProcRoot bud)
           alt = (Just SomeSharedMem, Just NoSwap)
           best = (Just ExactForIsolatedMem, Just NoSwap)
           containsInact = Text.isInfixOf "Inact_"
@@ -226,6 +225,10 @@ mkReportBud rbProcRoot rbPids = do
 
 pidPath :: FilePath -> FilePath -> ProcessID -> FilePath
 pidPath root base pid = "" +| root |+ "/" +| toInteger pid |+ "/" +| base |+ ""
+
+
+meminfoPathOf :: FilePath -> FilePath
+meminfoPathOf root = "" +| root |+ "/meminfo"
 
 
 canAccessRoot :: FilePath -> IO Bool

--- a/src/System/MemInfo/SysInfo.hs
+++ b/src/System/MemInfo/SysInfo.hs
@@ -218,5 +218,5 @@ mkReportBud rbProcRoot rbPids = do
             }
 
 
-pidPath :: FilePath -> String -> ProcessID -> FilePath
-pidPath root base pid = "" +| root |+ "" +| toInteger pid |+ "/" +| base |+ ""
+pidPath :: FilePath -> FilePath -> ProcessID -> FilePath
+pidPath root base pid = "" +| root |+ "/" +| toInteger pid |+ "/" +| base |+ ""

--- a/src/System/MemInfo/SysInfo.hs
+++ b/src/System/MemInfo/SysInfo.hs
@@ -203,7 +203,10 @@ mkReportBud rbProcRoot rbPids = do
     then pure Nothing
     else do
       rbHasSmaps <- doesFileExist smapsPath
-      (rbHasPss, rbHasSwapPss) <- memtypes <$> readUtf8Text smapsPath
+      (rbHasPss, rbHasSwapPss) <-
+        if rbHasSmaps
+          then memtypes <$> readUtf8Text smapsPath
+          else pure (False, False)
       readKernelVersion rbProcRoot >>= \case
         Nothing -> pure Nothing
         Just rbKernel ->

--- a/test/MemInfo/Files/Root.hs
+++ b/test/MemInfo/Files/Root.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module MemInfo.Files.Root (
+  -- * functions
+  useTmp,
+  writeRootedFile,
+  initRoot,
+  clearDirectory,
+) where
+
+import Data.Text (Text)
+import qualified Data.Text.IO as Text
+import Fmt ((+|), (|+))
+import System.Directory (
+  createDirectoryIfMissing,
+  listDirectory,
+  removePathForcibly,
+ )
+import System.FilePath (takeDirectory, (</>))
+import System.IO.Temp (withSystemTempDirectory)
+import System.MemInfo.SysInfo (
+  KernelVersion,
+ )
+
+
+useTmp :: (FilePath -> IO a) -> IO a
+useTmp = withSystemTempDirectory "mem-info"
+
+
+writeRootedFile :: FilePath -> FilePath -> Text -> IO ()
+writeRootedFile root path txt = do
+  let target = root </> path
+  createDirectoryIfMissing True $ takeDirectory target
+  Text.writeFile target txt
+
+
+initRoot :: FilePath -> KernelVersion -> IO ()
+initRoot root version = do
+  clearDirectory root
+  writeRootedFile root "sys/kernel/osrelease" $ fmtKernelVersion version
+
+
+clearDirectory :: FilePath -> IO ()
+clearDirectory fp = listDirectory fp >>= mapM_ removePathForcibly
+
+
+fmtKernelVersion :: KernelVersion -> Text
+fmtKernelVersion (major, minor, patch) =
+  "" +| toInteger major |+ "." +| toInteger minor |+ "." +| toInteger patch |+ ""

--- a/test/MemInfo/Files/Smap.hs
+++ b/test/MemInfo/Files/Smap.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module MemInfo.Files.Smap (
+  -- * data types
+
+  -- * functions
+  genSmapLine,
+  genBaseSmap',
+  genBaseSmap,
+  genWithPss,
+) where
+
+import Data.GenValidity (GenValid (..))
+import Data.Hashable (hash)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word16)
+import Fmt ((+|), (|+))
+import MemInfo.OrphanInstances ()
+import System.MemInfo.Proc (ProcUsage (..))
+import Test.QuickCheck
+
+
+genSmapLine :: Text -> Gen (Int, Text)
+genSmapLine prefix = do
+  x <- genValid :: Gen Word16
+  let txt = "" +| prefix |+ ": " +| x |+ " kB"
+  pure (fromIntegral x, txt)
+
+
+genBaseSmap :: Gen (ProcUsage, Text)
+genBaseSmap = do
+  (pp, txt, _) <- genBaseSmap'
+  pure (pp, txt)
+
+
+ppZero :: ProcUsage
+ppZero =
+  ProcUsage
+    { puPrivate = 0
+    , puShared = 0
+    , puSharedHuge = 0
+    , puSwap = 0
+    , puMemId = 0
+    }
+
+
+genBaseSmap' :: Gen (ProcUsage, Text, Int)
+genBaseSmap' = do
+  (clean, cleanTxt) <- genSmapLine "Private_Clean"
+  (dirty, dirtyTxt) <- genSmapLine "Private_Dirty"
+  (sharedClean, shCleanTxt) <- genSmapLine "Shared_Clean"
+  (sharedDirty, shDirtyTxt) <- genSmapLine "Shared_Dirty"
+  (privateHuge, phTxt) <- genSmapLine "Private_Hugetlb"
+  (sharedHuge, shTxt) <- genSmapLine "Shared_Hugetlb"
+  (swap, swapTxt) <- genSmapLine "Swap"
+  let pp =
+        ppZero
+          { puPrivate = clean + dirty + privateHuge
+          , puMemId = hash content
+          , puSwap = swap
+          , puSharedHuge = sharedHuge
+          , puShared = sharedClean + sharedDirty
+          }
+      content =
+        Text.unlines
+          [ phTxt
+          , dirtyTxt
+          , cleanTxt
+          , swapTxt
+          , shTxt
+          , shCleanTxt
+          , shDirtyTxt
+          ]
+  pure (pp, content, privateHuge)
+
+
+genWithPss :: Gen (ProcUsage, Text)
+genWithPss = genBaseSmap' >>= genAppendPss
+
+
+genAppendPss :: (ProcUsage, Text, Int) -> Gen (ProcUsage, Text)
+genAppendPss (pp, initial, puPrivateHuge) = do
+  (pss, txt) <- genSmapLine "Pss"
+  let content = initial <> "\n" <> txt
+      newShared = pss - (puPrivate pp - puPrivateHuge)
+  pure (pp {puShared = newShared, puMemId = hash content}, content)

--- a/test/MemInfo/MemInfoSpec.hs
+++ b/test/MemInfo/MemInfoSpec.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : MemInfo.SysInfoSpec
+Copyright   : (c) 2023 Tim Emiola
+Maintainer  : Tim Emiola <adetokunbo@emio.la>
+SPDX-License-Identifier: BSD3
+-}
+module MemInfo.MemInfoSpec (spec) where
+
+import Data.GenValidity (GenValid (..))
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as Text
+import Data.Word (Word16)
+import Fmt (blockMapF, build, fmt, (+|), (|+))
+import MemInfo.Files.Root (initRoot, useTmp, writeRootedFile)
+import MemInfo.Files.Smap (genBaseSmap)
+import MemInfo.OrphanInstances ()
+import System.Directory (createDirectoryIfMissing, createFileLink)
+import System.FilePath (takeDirectory, (</>))
+import System.MemInfo (readForOnePid', readMemUsage)
+import System.MemInfo.Proc (MemUsage, amass)
+import System.MemInfo.SysInfo (
+  KernelVersion,
+  mkReportBud,
+ )
+import Test.Hspec
+import Test.QuickCheck
+import Test.QuickCheck.Monadic (PropertyM, assert, monadicIO, pick, run)
+
+
+spec :: Spec
+spec = do
+  describe "module System.MemInfo.MemProc" $ around useTmp $ do
+    context "the proc fs stores mem info in <proc>/<id>/smap" $ do
+      context "and has 1 non-root process" $ do
+        context "readForOnePid'" $ do
+          it "should generate the correct report" prop_ReadOneSmapProcPid
+        context "readMemUsage'" $ do
+          it "should generate the correct report" prop_ReadSmapProcMemUsage
+
+
+prop_ReadSmapProcMemUsage :: FilePath -> Property
+prop_ReadSmapProcMemUsage root = monadicIO $ do
+  let fakeProc = "/usr/bin/true"
+  (wantedUsage, smapsTxt) <- pick genBaseSmap
+  let asReport = amass True [(fakeProc, wantedUsage)]
+      writeFiles = writeSmapProcFiles root smapsTxt fakeProc
+  verifyReadMemUsage root asReport gen3xKernel writeFiles
+
+
+verifyReadMemUsage ::
+  FilePath ->
+  Map Text MemUsage ->
+  Gen KernelVersion ->
+  (Word16 -> IO ()) ->
+  PropertyM IO ()
+verifyReadMemUsage root expected genKernel writeFiles = do
+  thePid <- pick genValidProcId
+  version <- pick genKernel
+  -- some matches are incomplete, that's ok, the test should fail if they fai
+  Right procMap <- run $ do
+    initRoot root version
+    writeFiles thePid
+    Just bud <- mkReportBud root (fromIntegral thePid :| [])
+    readMemUsage bud
+  assert (expected == procMap)
+
+
+prop_ReadOneSmapProcPid :: FilePath -> Property
+prop_ReadOneSmapProcPid root = monadicIO $ do
+  let fakeProc = "/usr/bin/true"
+  (wantedUsage, smapsTxt) <- pick genBaseSmap
+  let asReport = amass True [(fakeProc, wantedUsage)]
+      writeFiles = writeSmapProcFiles root smapsTxt fakeProc
+  verifyReadForOnePid root asReport gen3xKernel writeFiles
+
+
+verifyReadForOnePid ::
+  FilePath ->
+  Map Text MemUsage ->
+  Gen KernelVersion ->
+  (Word16 -> IO ()) ->
+  PropertyM IO ()
+verifyReadForOnePid root expected genKernel writeFiles = do
+  thePid <- pick genValidProcId
+  version <- pick genKernel
+  -- this match is incomplete, that's ok, the test fails if the run produces a Left
+  Right (theProc, theUsage) <- run $ do
+    initRoot root version
+    writeFiles thePid
+    readForOnePid' root $ fromIntegral thePid
+  assert (Map.lookup theProc expected == Just theUsage)
+
+
+gen3xKernel :: Gen KernelVersion
+gen3xKernel = do
+  patch <- genValid
+  minor <- genValid
+  pure (3, minor, patch)
+
+
+writeSmapProcFiles :: FilePath -> Text -> Text -> Word16 -> IO ()
+writeSmapProcFiles root txt procName thePid = do
+  let fakeParent = "/sbin/fake"
+  writeRootedExeAndCmdLine root fakeParent 1
+  writeRootedExeAndCmdLine root procName thePid
+  writeRootedFakeStatus root procName thePid 1
+  writeRootedFile root ("" +| thePid |+ "/smaps") txt
+
+
+genValidProcId :: Gen Word16
+genValidProcId = genValid `suchThat` (> 1)
+
+
+writeRootedExeAndCmdLine :: FilePath -> Text -> Word16 -> IO ()
+writeRootedExeAndCmdLine root fakeProc procId = do
+  writeRootedFile root ("" +| procId |+ "/cmdline") fakeProc
+  writeRootedExeLink root ("" +| procId |+ "/exe") fakeProc
+
+
+writeRootedFakeStatus :: FilePath -> Text -> Word16 -> Word16 -> IO ()
+writeRootedFakeStatus root fakeProc procId parentId = do
+  let txt = fmt $ blockMapF $ statusInfoFields fakeProc parentId
+      statusPath = "" +| procId |+ "/status"
+  writeRootedFile root statusPath txt
+
+
+statusInfoFields :: Text -> Word16 -> [(Text, Text)]
+statusInfoFields fakeProc parentId =
+  [ ("Name", fakeProc)
+  , ("PPid", fmt $ build $ toInteger parentId)
+  ]
+
+
+writeRootedExeLink :: FilePath -> FilePath -> Text -> IO ()
+writeRootedExeLink root path link = do
+  let target = root </> path
+  createDirectoryIfMissing True $ takeDirectory target
+  createFileLink (Text.unpack link) target

--- a/test/MemInfo/OrphanInstances.hs
+++ b/test/MemInfo/OrphanInstances.hs
@@ -27,6 +27,7 @@ import System.MemInfo.Choices (
   Power,
   PrintOrder,
   Style,
+  defaultRoot,
  )
 import System.MemInfo.Proc (ExeInfo (..), StatusInfo)
 import System.Posix.Types (CPid (..), ProcessID)
@@ -106,6 +107,7 @@ instance GenValid Choices where
           <*> genValid
           <*> genValid
           <*> genValid
+          <*> pure defaultRoot
           <*> genPositiveMb
           <*> genPids
           <*> genValid

--- a/test/MemInfo/ProcSpec.hs
+++ b/test/MemInfo/ProcSpec.hs
@@ -7,7 +7,11 @@ Copyright   : (c) 2023 Tim Emiola
 Maintainer  : Tim Emiola <adetokunbo@emio.la>
 SPDX-License-Identifier: BSD3
 -}
-module MemInfo.ProcSpec (spec) where
+module MemInfo.ProcSpec (
+  spec,
+  genBaseSmap,
+  genSmapLine,
+) where
 
 import Data.Hashable (hash)
 import Data.Maybe (isNothing)

--- a/test/MemInfo/ProcSpec.hs
+++ b/test/MemInfo/ProcSpec.hs
@@ -11,7 +11,7 @@ module MemInfo.ProcSpec (
   spec,
   genBaseSmap,
   genSmapLine,
-  genAppendSwapPss,
+  genWithPss,
 ) where
 
 import Data.Hashable (hash)

--- a/test/MemInfo/SysInfoSpec.hs
+++ b/test/MemInfo/SysInfoSpec.hs
@@ -19,8 +19,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import Data.Word (Word16, Word8)
 import Fmt (blockMapF, build, fmt, (+|), (|+))
+import MemInfo.Files.Smap (genBaseSmap, genSmapLine, genWithPss)
 import MemInfo.OrphanInstances ()
-import MemInfo.ProcSpec (genBaseSmap, genSmapLine, genWithPss)
 import System.Directory (createDirectoryIfMissing, createFileLink, listDirectory, removePathForcibly)
 import System.FilePath (takeDirectory, (</>))
 import System.IO.Temp (withSystemTempDirectory)


### PR DESCRIPTION
Adds the flag `--proc-root`

to implement a [ps_mem feature request](https://github.com/pixelb/ps_mem/issues/27)

Used to specify an alternate process root than the default, `/proc`. This allows reporting of process status for other machines whose proc information has been mounted or synced to a local filesystem 
